### PR TITLE
Non-issue : Changed include method for external PHP files.

### DIFF
--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -37,19 +37,16 @@ class ConfigFactory extends SimpleFactory implements ConfigFactoryInterface
             $data = [];
             $config = new Config($data, $overwriteHandler);
 
-            foreach ($files as $file)
-            {
+            foreach ($files as $file) {
                 $ext = $file['extension'];
-                $contents = $fs->read($file['path']);
                 $data = [];
-
-                if ($ext === 'php')
-                {
-                    $data = require "data://text/plain;base64," . base64_encode($contents);
-                }
-                else if (isset($parsers[$ext]))
-                {
-                    $data = $parsers[$ext]->decode($contents);
+                if ($ext === 'php') {
+                    $data = $fs->req($file['path']);
+                } else {
+                    if (isset($parsers[$ext])) {
+                        $contents = $fs->read($file['path']);
+                        $data = $parsers[$ext]->decode($contents);
+                    }
                 }
 
                 $config->merge($data);

--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -37,16 +37,18 @@ class ConfigFactory extends SimpleFactory implements ConfigFactoryInterface
             $data = [];
             $config = new Config($data, $overwriteHandler);
 
-            foreach ($files as $file) {
+            foreach ($files as $file)
+            {
                 $ext = $file['extension'];
                 $data = [];
-                if ($ext === 'php') {
+                if ($ext === 'php')
+                {
                     $data = $fs->req($file['path']);
-                } else {
-                    if (isset($parsers[$ext])) {
-                        $contents = $fs->read($file['path']);
-                        $data = $parsers[$ext]->decode($contents);
-                    }
+                }
+                else if (isset($parsers[$ext]))
+                {
+                    $contents = $fs->read($file['path']);
+                    $data = $parsers[$ext]->decode($contents);
                 }
 
                 $config->merge($data);

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -448,7 +448,7 @@ class Filesystem implements FilesystemInterface
      */
     public function req($path)
     {
-        return "data://text/plain;base64," . base64_encode($this->read($path));
+        return eval('?>' . $this->read($path));
     }
 
     /**

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -448,7 +448,13 @@ class Filesystem implements FilesystemInterface
      */
     public function req($path)
     {
-        return eval('?>' . $this->read($path));
+        $result = eval('?>' . $this->read($path));
+        if (is_null($result))
+        {
+            $result = '';
+        }
+
+        return $result;
     }
 
     /**

--- a/test/_Module/Filesystem/_Abstract/FilesystemTestAbstract.php
+++ b/test/_Module/Filesystem/_Abstract/FilesystemTestAbstract.php
@@ -160,6 +160,7 @@ abstract class FilesystemTestAbstract extends TModule
         file_put_contents($path . '/FILE_B.txt', 'FILE_B_TEXT');
         file_put_contents($path . '/DIR_A/FILE_C', 'FILE_C_TEXT');
         file_put_contents($path . '/FILE_D', 'FILE_D_TEXT');
+        file_put_contents($path . '/FILE_E', '<?php return "FILE_E_TEXT";');
         chmod($path . '/DIR_D',  0700);
         chmod($path . '/FILE_D', 0700);
     }
@@ -175,7 +176,6 @@ abstract class FilesystemTestAbstract extends TModule
     /**
      * @param string $path
      * @param bool $recursive
-     * @param callable $nameFilter
      * @return array
      */
     private function getPathAllData($path, $recursive)

--- a/test/_Module/Filesystem/_Partial/Filesystem/FsApiCreatePartial.php
+++ b/test/_Module/Filesystem/_Partial/Filesystem/FsApiCreatePartial.php
@@ -2,7 +2,6 @@
 
 namespace Kraken\_Module\Filesystem\_Partial\Filesystem;
 
-use Kraken\Filesystem\Filesystem;
 use Kraken\Filesystem\FilesystemInterface;
 use Kraken\Test\TModule;
 use Kraken\Throwable\Exception\Runtime\WriteException;

--- a/test/_Module/Filesystem/_Partial/Filesystem/FsApiReqPartial.php
+++ b/test/_Module/Filesystem/_Partial/Filesystem/FsApiReqPartial.php
@@ -56,19 +56,19 @@ trait FsApiReqPartial
     {
         $test = $this->getTest();
         $fs = $this->createFilesystem();
-        $contents = $this->encodeReq('FILE_A_TEXT');
+        $contents = 'FILE_E_TEXT';
 
-        $test->assertEquals($contents, $fs->req($this->getPrefixed('FILE_A')));
+        $test->assertEquals($contents, $fs->req($this->getPrefixed('FILE_E')));
     }
 
     /**
      *
      */
-    public function testApiReq_ReturnsEmptyString_WhenPathDoesExistButIsNotValid()
+    public function testApiReq_ReturnsNull_WhenPathDoesExistButIsNotValid()
     {
         $test = $this->getTest();
         $fs = $this->createFilesystem();
-        $contents = $this->encodeReq('');
+        $contents = null;
 
         $test->assertEquals($contents, $fs->req($this->getPrefixed('DIR_A')));
     }
@@ -84,14 +84,5 @@ trait FsApiReqPartial
         $test->setExpectedException(ReadException::class);
 
         $fs->req($this->getPrefixed('FILE_NULL'));
-    }
-
-    /**
-     * @param string $str
-     * @return string
-     */
-    private function encodeReq($str)
-    {
-        return "data://text/plain;base64," . base64_encode($str);
     }
 }

--- a/test/_Module/Filesystem/_Partial/Filesystem/FsApiReqPartial.php
+++ b/test/_Module/Filesystem/_Partial/Filesystem/FsApiReqPartial.php
@@ -64,11 +64,11 @@ trait FsApiReqPartial
     /**
      *
      */
-    public function testApiReq_ReturnsNull_WhenPathDoesExistButIsNotValid()
+    public function testApiReq_ReturnsEmptyString_WhenPathDoesExistButIsNotValid()
     {
         $test = $this->getTest();
         $fs = $this->createFilesystem();
-        $contents = null;
+        $contents = '';
 
         $test->assertEquals($contents, $fs->req($this->getPrefixed('DIR_A')));
     }

--- a/test/_Unit/Filesystem/FilesystemTest.php
+++ b/test/_Unit/Filesystem/FilesystemTest.php
@@ -678,15 +678,16 @@ class FilesystemTest extends TUnit
     /**
      *
      */
-    public function testApiReq_UsesDataStreamToIncludePhpFilesFromExternalSources()
+    public function testApiReq_UsesEvalToIncludePhpFilesFromExternalSources()
     {
         $path = 'path';
+        $code = '<?php return "XYZ";';
         $str = 'XYZ';
 
-        $this->expect('read', [ $path ])->willReturn($str);
+        $this->expect('read', [ $path ])->willReturn($code);
 
         $this->assertEquals(
-            "data://text/plain;base64," . base64_encode($str),
+            $str,
             $this->fs->req($path)
         );
     }


### PR DESCRIPTION
Using data streams in require/include statements requires `allow_url_include` and `allow_url_fopen` directives to be enabled, which is considered as a potential security vulnerability.
Also base64 encoding/decoding adds extra overhead. Eval in this case performs more than 2x faster.
